### PR TITLE
Test on CINIC-10 dataset

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ from utils import progress_bar
 
 
 parser = argparse.ArgumentParser(description='PyTorch CIFAR10 Training')
-parser.add_argument('--lr', default=0.1, type=float, help='learning rate')
+parser.add_argument('--lr', default=0.01, type=float, help='learning rate')
 parser.add_argument('--resume', '-r', action='store_true', help='resume from checkpoint')
 parser.add_argument('--fp16', action='store_true', help='enable FP16')
 parser.add_argument('--epoch', default=50, type=int, help='learning rate')
@@ -30,27 +30,32 @@ start_epoch = 0  # start from epoch 0 or last checkpoint epoch
 # you might need to change lr along with bs for good accuracy.
 bs = int(args.bs)
 
+# CINIC-10 Data
+cinic_dir = 'CINIC-10'
+cinic_mean = [0.47889522, 0.47227842, 0.43047404]
+cinic_std = [0.24205776, 0.23828046, 0.25874835]
+
 # Data
 print('==> Preparing data..')
 transform_train = transforms.Compose([
-    transforms.RandomCrop(32, padding=4),
+    transforms.RandomCrop(32, padding=1),
     transforms.RandomHorizontalFlip(),
     transforms.ToTensor(),
-    transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
+    transforms.Normalize(cinic_mean, cinic_std),
 ])
 
 transform_test = transforms.Compose([
     transforms.ToTensor(),
-    transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
+    transforms.Normalize(cinic_mean, cinic_std),
 ])
 
-trainset = torchvision.datasets.CIFAR10(root='./data', train=True, download=True, transform=transform_train)
-trainloader = torch.utils.data.DataLoader(trainset, batch_size=128, shuffle=True, num_workers=2)
+trainset = torchvision.datasets.ImageFolder(cinic_dir + '/train', transform=transform_train)
+trainloader = torch.utils.data.DataLoader(trainset, batch_size=128, shuffle=True, num_workers=5)
 
-testset = torchvision.datasets.CIFAR10(root='./data', train=False, download=True, transform=transform_test)
-testloader = torch.utils.data.DataLoader(testset, batch_size=100, shuffle=False, num_workers=2)
+testset = torchvision.datasets.ImageFolder(cinic_dir + '/test', transform=transform_test)
+testloader = torch.utils.data.DataLoader(testset, batch_size=80, shuffle=False, num_workers=5)
 
-classes = ('plane', 'car', 'bird', 'cat', 'deer', 'dog', 'frog', 'horse', 'ship', 'truck')
+classes = ('airplane', 'automobile', 'bird', 'cat', 'deer', 'dog', 'frog', 'horse', 'ship', 'truck')
 
 # Model
 print('==> Building model..')


### PR DESCRIPTION
CINIC-10 dataset: [https://datashare.is.ed.ac.uk/handle/10283/3192](url)


There are certain changes on `main.py` file, named `cinic_torch.py` in this repository. The first change is on data loading directory to CINIC-10 dataset folder
```python
cinic_dir = 'CINIC-10'
trainset = torchvision.datasets.ImageFolder(cinic_dir + '/train', transform=transform_train)
trainloader = torch.utils.data.DataLoader(trainset, batch_size=128, shuffle=True, num_workers=5)

testset = torchvision.datasets.ImageFolder(cinic_dir + '/test', transform=transform_test)
testloader = torch.utils.data.DataLoader(testset, batch_size=80, shuffle=False, num_workers=5)

classes = ('airplane', 'automobile', 'bird', 'cat', 'deer', 'dog', 'frog', 'horse', 'ship', 'truck')
```

Next, to adjust with CINIC-10 dataset, transform normalize value has been changed as
```python
cinic_mean = [0.47889522, 0.47227842, 0.43047404]
cinic_std = [0.24205776, 0.23828046, 0.25874835]

transform_train = transforms.Compose([
    transforms.RandomCrop(32, padding=1),
    transforms.RandomHorizontalFlip(),
    transforms.ToTensor(),
    transforms.Normalize(cinic_mean, cinic_std),
])

transform_test = transforms.Compose([
    transforms.ToTensor(),
    transforms.Normalize(cinic_mean, cinic_std),
])
```

Lastly, the learning rate which is used in this training is `lr = 0.01`